### PR TITLE
Hide logo and authors in input modal

### DIFF
--- a/src/one-thing@organisation.mail.com/prefs.js
+++ b/src/one-thing@organisation.mail.com/prefs.js
@@ -34,8 +34,8 @@ class PrefsWidget {
         });
         this.vbox.set_size_request(60, 60);
         this.vbox.append(this.addTextUrl());
-        this.vbox.append(this.addPicture());
-        this.vbox.append(this.addAuthors());
+        //this.vbox.append(this.addPicture());
+        //this.vbox.append(this.addAuthors());
         this.widget.append(this.vbox);
     }
 


### PR DESCRIPTION
That’s quite distracting in there, we can just use the meta info for that. :)